### PR TITLE
fix: resolve Unicode encoding errors on Windows (cp1252)

### DIFF
--- a/src/beads/commands/dep.py
+++ b/src/beads/commands/dep.py
@@ -66,7 +66,7 @@ def dep_remove(ctx: BeadsContext, issue_id: str, depends_on_id: str) -> None:
     ctx.auto_flush()
 
     if not ctx.quiet:
-        click.echo(f"Removed dependency: {full_issue} → {full_depends}")
+        click.echo(f"Removed dependency: {full_issue} -> {full_depends}")
 
 
 @dep.command("list")
@@ -94,11 +94,11 @@ def dep_list(ctx: BeadsContext, issue_id: str) -> None:
             dep_issue = ctx.store.get_issue(d.depends_on_id)
             title = dep_issue.title if dep_issue else "(unknown)"
             status = dep_issue.status if dep_issue else "?"
-            click.echo(f"  → {d.depends_on_id} [{d.type}] ({status}) {truncate(title)}")
+            click.echo(f"  -> {d.depends_on_id} [{d.type}] ({status}) {truncate(title)}")
     else:
         click.echo(f"No dependencies for {full_id}")
 
     if dependents:
         click.echo(f"\nDepended on by:")
         for d in dependents:
-            click.echo(f"  ← {d.id} ({d.status}) {truncate(d.title)}")
+            click.echo(f"  <- {d.id} ({d.status}) {truncate(d.title)}")

--- a/src/beads/commands/doctor.py
+++ b/src/beads/commands/doctor.py
@@ -20,7 +20,7 @@ def doctor(ctx: BeadsContext) -> None:
     issues_found = 0
 
     click.echo("Beads Doctor")
-    click.echo("─" * 40)
+    click.echo("-" * 40)
 
     # Check .beads/ directory
     click.echo(f"  .beads/ directory: {ctx.beads_dir}")

--- a/src/beads/commands/show.py
+++ b/src/beads/commands/show.py
@@ -36,9 +36,9 @@ def show(ctx: BeadsContext, issue_id: str) -> None:
         return
 
     # Header
-    click.echo(f"{'─' * 60}")
+    click.echo(f"{'-' * 60}")
     click.echo(f"  {issue.id}")
-    click.echo(f"{'─' * 60}")
+    click.echo(f"{'-' * 60}")
     click.echo(f"  Title:    {issue.title}")
     click.echo(f"  Status:   {issue.status}")
     click.echo(f"  Priority: {format_priority(issue.priority)} ({priority_label(issue.priority)})")
@@ -95,14 +95,14 @@ def show(ctx: BeadsContext, issue_id: str) -> None:
             dep_issue = ctx.store.get_issue(dep.depends_on_id)
             dep_title = dep_issue.title if dep_issue else "(unknown)"
             dep_status = dep_issue.status if dep_issue else "?"
-            click.echo(f"    → {dep.depends_on_id} [{dep.type}] ({dep_status}) {dep_title}")
+            click.echo(f"    -> {dep.depends_on_id} [{dep.type}] ({dep_status}) {dep_title}")
 
     # Dependents
     dependents = ctx.store.get_dependents(full_id)
     if dependents:
         click.echo(f"\n  Blocked by this:")
         for dep in dependents:
-            click.echo(f"    ← {dep.id} ({dep.status}) {dep.title}")
+            click.echo(f"    <- {dep.id} ({dep.status}) {dep.title}")
 
     # Comments
     comments = ctx.store.get_comments(full_id)

--- a/src/beads/commands/stats.py
+++ b/src/beads/commands/stats.py
@@ -34,7 +34,7 @@ def stats(ctx: BeadsContext) -> None:
         return
 
     click.echo("Project Statistics")
-    click.echo("─" * 40)
+    click.echo("-" * 40)
     click.echo(f"  Total:       {s.total_issues}")
     click.echo(f"  Open:        {s.open_issues}")
     click.echo(f"  In Progress: {s.in_progress_issues}")

--- a/src/beads/export.py
+++ b/src/beads/export.py
@@ -44,7 +44,7 @@ def flush_to_jsonl(store: Storage, jsonl_path: str, verbose: bool = False) -> in
     tmp_path = jsonl_path + ".tmp"
     count = 0
     try:
-        with open(tmp_path, "w") as f:
+        with open(tmp_path, "w", encoding="utf-8") as f:
             for issue in enriched:
                 line = json.dumps(issue.to_dict(), ensure_ascii=False, separators=(",", ":"))
                 f.write(line + "\n")

--- a/src/beads/importer.py
+++ b/src/beads/importer.py
@@ -44,7 +44,7 @@ def parse_jsonl(jsonl_path: str) -> tuple[list[Issue], list[str]]:
     if not os.path.exists(jsonl_path):
         return issues, deletion_ids
 
-    with open(jsonl_path) as f:
+    with open(jsonl_path, encoding="utf-8") as f:
         for line_num, line in enumerate(f, 1):
             line = line.strip()
             if not line:

--- a/src/beads/storage/sqlite_store.py
+++ b/src/beads/storage/sqlite_store.py
@@ -650,7 +650,7 @@ class SQLiteStorage(Storage):
         # Cycle detection
         if self.has_cycle(dep.issue_id, dep.depends_on_id):
             raise ValueError(
-                f"Adding dependency {dep.issue_id} → {dep.depends_on_id} would create a cycle"
+                f"Adding dependency {dep.issue_id} -> {dep.depends_on_id} would create a cycle"
             )
         self._conn.execute(
             "INSERT OR IGNORE INTO dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id) "


### PR DESCRIPTION
Force UTF-8 encoding for JSONL file I/O and replace Unicode box-drawing and arrow characters with ASCII equivalents in CLI output.

Closes #1